### PR TITLE
Fix parser reduce conflicts

### DIFF
--- a/autogentoo/cportage/depend_bison.y
+++ b/autogentoo/cportage/depend_bison.y
@@ -78,7 +78,7 @@ program_depend : DEPEND depend_expr                {dependout = (void*)$2;}
                ;
 
 depend_expr  : depend_expr_single               {$$ = $1;}
-             | depend_expr depend_expr          {$$ = $1; $$->next = $2;}
+             | depend_expr_single depend_expr   {$$ = $1; $$->next = $2;}
 
 depend_expr_single  : atom                          {$$ = dependency_build_atom($1);}
                     | USESELECT '(' depend_expr ')' {$$ = dependency_build_use($1.target, $1.operator, $3); free($1.target);}

--- a/autogentoo/cportage/requireduse_bison.y
+++ b/autogentoo/cportage/requireduse_bison.y
@@ -69,7 +69,7 @@ required_use_single : depend_expr_sel '(' required_use_expr ')' {
                     ;
 
 required_use_expr   : required_use_single                         {$$ = $1;}
-                    | required_use_expr required_use_expr         {$$ = $1; $$->next = $2;}
+                    | required_use_single required_use_expr       {$$ = $1; $$->next = $2;}
                     ;
 
 use_expr     : '!' IDENTIFIER        {$$.target = $2; $$.operator = USE_OP_DISABLE;}

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -3,15 +3,6 @@ function(setup_cmocka)
     include(${CMAKE_SOURCE_DIR}/cmake/AddMockedTest.cmake)
 endfunction()
 
-set(CMAKE_DISABLED_TESTS ${CMAKE_DISABLED_TESTS})
-
-macro(set_tests_properties target)
-    if (${target} IN_LIST CMAKE_DISABLED_TESTS)
-    else()
-        _set_tests_properties(${ARGV})
-    endif()
-endmacro()
-
 setup_cmocka()
 enable_testing()
 add_subdirectory(${CMAKE_SOURCE_DIR}/autogentoo/test)


### PR DESCRIPTION
Fixed bison warnings about reduce/shift conflicts. Don't use two recursive expressions inside one rule because they
could both be expanded. Instead, use a 'single' rule followed by the recursive rule.