### PR TITLE
Update neoast to use compile-time FSM for regex

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         run: pip install black mypy
 
       - name: Run linters
-        uses: wearerequired/lint-action@v1
+        uses: wearerequired/lint-action@v1.10.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Enable linters

--- a/.idea/AutoGentoo.iml
+++ b/.idea/AutoGentoo.iml
@@ -1,2 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module classpath="CMake" type="CPP_MODULE" version="4" />
+<module classpath="CMake" type="CPP_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="Python" name="Python facet">
+      <configuration sdkName="Python 3.9 (AutoGentoo)" />
+    </facet>
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -6,7 +6,5 @@
     <mapping directory="$PROJECT_DIR$/third_party/cmocka" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/third_party/neoast" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/third_party/neoast/third_party/cmocka" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/third_party/neoast/third_party/cre2" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/third_party/neoast/third_party/re2" vcs="Git" />
   </component>
 </project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ if (SANITIZER_BUILD)
     add_link_options(-fsanitize=address)
 
     set(LD_PRELOAD "LD_PRELOAD=${ASAN_LIB}")
+    set(EXEC_ENV ${EXEC_ENV} LSAN_OPTIONS=suppressions=data/leak.supp)
 
     message(STATUS "Building with AddressSanitizer")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ set(Python3_FIND_VIRTUALENV "ONLY")
 find_package(Python3 COMPONENTS Development)
 
 add_compile_definitions(_GNU_SOURCE)
-add_compile_options(-Wno-unused-result -g -fno-omit-frame-pointer)
+add_compile_options(-Wno-unused-result -g -fno-omit-frame-pointer -fPIC)
 add_link_options(-fno-omit-frame-pointer)
 
 set(EXEC_ENV "PYTHONPATH=${CMAKE_SOURCE_DIR}")
@@ -39,7 +39,6 @@ if (SANITIZER_BUILD)
     add_link_options(-fsanitize=address)
 
     set(LD_PRELOAD "LD_PRELOAD=${ASAN_LIB}")
-    set(EXEC_ENV ${EXEC_ENV} LSAN_OPTIONS=suppressions=data/leak.supp)
 
     message(STATUS "Building with AddressSanitizer")
 endif()

--- a/autogentoo/cportage/depend.y
+++ b/autogentoo/cportage/depend.y
@@ -1,8 +1,10 @@
-%top {
-#include <stdlib.h>
-#include <string.h>
-#include "dependency.h"
-#include "use.h"
+%include {
+    #include <stdlib.h>
+    #include <string.h>
+    #include "dependency.h"
+    #include "use.h"
+    #include "atom.h"
+    #include "common.h"
 }
 
 %option prefix="depend"
@@ -104,6 +106,7 @@ Atom* atom_parse(void* buffers, const char* input)
 "[ \t\r\\]+"            {/* skip */}
 "{repo}"                {yyval->identifier = strdup(yytext + 2); return REPOSITORY;}
 "{slot}"                {
+                            size_t len = yylen;
                             yyval->slot.slot_opts = ATOM_SLOT_IGNORE;
                             if (yytext[len - 1] == '*') {
                                 yyval->slot.slot_opts = ATOM_SLOT_IGNORE;
@@ -203,7 +206,7 @@ Atom* atom_parse(void* buffers, const char* input)
                                 yyval->depend_expr_select.operator = USE_OP_ENABLE;
                             }
 
-                            yyval->depend_expr_select.target = strndup(yytext, len - 1);
+                            yyval->depend_expr_select.target = strndup(yytext, yylen - 1);
                             return USESELECT;
                         }
 "\?\?"                  {yyval->depend_expr_select.target = NULL; yyval->depend_expr_select.operator = USE_OP_MOST_ONE; return USESELECT;}

--- a/autogentoo/cportage/requireduse.y
+++ b/autogentoo/cportage/requireduse.y
@@ -1,7 +1,9 @@
-%top {
-#include <assert.h>
-#include "dependency.h"
-#include "use.h"
+%include {
+    #include <assert.h>
+    #include "dependency.h"
+    #include "use.h"
+    #include "atom.h"
+    #include "common.h"
 }
 
 // This is default, just want to test the parser

--- a/autogentoo/test/network_test.py
+++ b/autogentoo/test/network_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import sys
 import unittest
+from typing import List, Optional
 
 from autogentoo import network
 
@@ -19,7 +20,7 @@ class TestStringMethods(unittest.TestCase):
     def test_simple_message(self):
         s_message = network.build_message(0, 2, 3, 4, 5, 6)
 
-        d = [None]
+        d: List[Optional[network.Message]] = [None]
 
         def cb(message: network.Message):
             d[0] = message

--- a/autogentoo/test/portage_test.py
+++ b/autogentoo/test/portage_test.py
@@ -41,22 +41,17 @@ class PortageUnitTests(unittest.TestCase):
             for x in resolve_all(None, Dependency(">=sys-devel/gcc-9.3.0")):
                 layer_one.append(x.get_resolved())
 
-    @unittest.expectedFailure
     def test_resolve_gcc(self):
         ebuild_n = self.portage.initialize_repository(None, "data/cportage-repo")
         self.assertEqual(ebuild_n, 30260)
 
         request_atom = Dependency("sys-devel/gcc")
 
-        for x in resolve_all(None, request_atom):
-            resolved = x.get_resolved()
-            print(resolved, flush=True)
-
-            try:
+        # TODO(tumbar) Fix portage resolution algorithm
+        with self.assertRaises(RequiredUseException):
+            for x in resolve_all(None, request_atom):
                 resolved = x.get_resolved()
                 print(resolved, flush=True)
-            except RequiredUseException as r_use:
-                print(r_use.suggestion, flush=True)
 
 
 if __name__ == "__main__":

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -4,5 +4,4 @@ function(setup_cmocka)
 endfunction()
 
 setup_cmocka()
-enable_testing()
 add_subdirectory(${CMAKE_SOURCE_DIR}/autogentoo/test)

--- a/data/leak.supp
+++ b/data/leak.supp
@@ -1,0 +1,2 @@
+# Python memory leaks!!
+leak:libpython*

--- a/data/leak.supp
+++ b/data/leak.supp
@@ -1,7 +1,0 @@
-# Python memory leaks!!
-leak:libpython*
-
-# Caused by a bug (maybe from me) in Flex/Bison error handling
-# Somehow the issue is not seen from calling in Python
-# Probably just going to leave this as is
-# leak:_IO_file_doallocate


### PR DESCRIPTION
For consistency I ran another benchmark before and after this PR with `-O2 -march=native`:

| Branch | cportage_C runtime |
|-----------|----------------------------|
| master | 13.30s |
| neoast-reflex | 1.47s |
